### PR TITLE
Gather data for DGW before hardfork

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1476,6 +1476,11 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     }
     if (pindexLast->nHeight < 1000) 
 	{
+		if (pindexLast->nHeight < 975)
+		{
+			printf("Gathering data for DGW...");
+			DarkGravityWave3(pindexLast, pblock);
+		}
         return GetNextWorkRequired_v1(pindexLast, pblock);
 	}
     return DarkGravityWave3(pindexLast, pblock);


### PR DESCRIPTION
to prevent diff=1 when DGW kicks in
